### PR TITLE
Fix for issue#4 : WSDL.prototype.objectToXML is not handling namespac…

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -862,14 +862,14 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns) {
                 parts.push(['</',ns,name,'>'].join(''));
                 parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
             }
-            parts.push(self.objectToXML(item, name));
+            parts.push(self.objectToXML(item, name, namespace, xmlns));
         }
     }
     else if (typeof obj === 'object') {
         for (var name in obj) {
             var child = obj[name];
             parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
-            parts.push(self.objectToXML(child, name));
+            parts.push(self.objectToXML(child, name, namespace, xmlns));
             parts.push(['</',ns,name,'>'].join(''));
         }
     }


### PR DESCRIPTION
WSDL.prototype.objectToXML is not handling namespaces for children