### PR TITLE
add license section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,7 @@
     "browser",
     "client"
   ],
-  "licenses": [
-    {
-      "type": "MIT License",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license" : "MIT",
   "devDependencies": {
     "uglify-js": "^3.3.9"
   }


### PR DESCRIPTION
According to https://docs.npmjs.com/files/package.json#license the licences section in package.json is deprecated now. The benefit of updating the package.json license section to the currents specs would be that the tinysoap npm can be processed by the webjars building environment. So tinysoap becomes also available as an webjar (https://www.webjars.org/).