### PR TITLE
Fix for issue#4 : WSDL.prototype.objectToXML is not handling namespaces for children

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -79,7 +79,8 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
     var p;
     if (secure)  p = require('https')
     else p = require("http")
-
+    if(data)
+       options.body = data; 
     var request = p.request(options, function (res, body) {
       var body = "";
       res.on('data', function (chunk) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -96,7 +96,7 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
     out.query = {};
   }
   if (rest) out.pathname = rest;
-  out.path = out.pathname + out.search;
+  out.path = out.pathname + (out.search || '');
   return out;
 }
 // format a parsed object into a url string

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -862,14 +862,14 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns) {
                 parts.push(['</',ns,name,'>'].join(''));
                 parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
             }
-            parts.push(self.objectToXML(item, name, namespace, xmlns));
+            parts.push(self.objectToXML(item, name));
         }
     }
     else if (typeof obj === 'object') {
         for (var name in obj) {
             var child = obj[name];
             parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
-            parts.push(self.objectToXML(child, name, namespace, xmlns));
+            parts.push(self.objectToXML(child, name));
             parts.push(['</',ns,name,'>'].join(''));
         }
     }


### PR DESCRIPTION
1. SOAP Action :  revert
2. Method name
3. request body
4. Fix for issue#4 : WSDL.prototype.objectToXML is not handling namespaces for children
